### PR TITLE
front: fix: proxy port 수정

### DIFF
--- a/front/vue.config.js
+++ b/front/vue.config.js
@@ -6,7 +6,7 @@ module.exports = defineConfig({
   devServer: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8085',
+        target: 'http://localhost:8080',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
front API 호출 시 서버의 port를 따라가야 하나 front 서버의 port로 기입하여 수정